### PR TITLE
MP Actions convergence (Phase 1) — broker: F1-F6 enforcement + derived scopes

### DIFF
--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -202,6 +202,27 @@ export function createBroker({
     }
   }
 
+  /**
+   * F2 — condition reads were unmediated: no authz, no scope, no equivalent of
+   * `authorizeInvoke`, so any MP could read any other MP's conditions
+   * (kiosk PINs, vendor settings, client records). The scope name MIRRORS the
+   * invoke convention exactly — `read:{ownerMpId}.{conditionName}` where
+   * invoke uses `invoke:{ownerMpId}.{activityName}` — including the '*' host
+   * authority marker and the same-MP (callerIsTarget) exemption.
+   *
+   * Gated on `enforceConditionScopes` (default OFF): no manifest declares a
+   * `read:` scope for a cross-MP condition yet.
+   */
+  function authorizeQuery(callerMpId, ownerMpId, conditionName, scopes) {
+    if (!enforceConditionScopes) return;
+    if (callerMpId === ownerMpId) return; // an MP always reads its own conditions
+    const scope = `read:${qualify(ownerMpId, conditionName)}`;
+    const held = scopes || [];
+    if (!held.includes(scope) && !held.includes('*')) {
+      throw err('PermissionDenied', `caller lacks scope '${scope}'`, { rule: 'permissions', retryable: false });
+    }
+  }
+
   // --- Active Trigger Index (D21) -------------------------------------------
 
   function actionKey(tenantId, mpId, actionId) { return `${tenantId}:${mpId}:${actionId}`; }
@@ -464,6 +485,8 @@ export function createBroker({
     const ownerEntry = mps.get(ownerMpId);
     const conditionDef = ownerEntry?.manifest.conditions?.[conditionName];
     if (!conditionDef) throw err('UnknownCondition', `condition '${envelope.condition}' is not registered`, { retryable: false });
+
+    authorizeQuery(envelope.sourceMpId, ownerMpId, conditionName, identity.scopes);
     validateAgainst(conditionDef.inputSchema, envelope.args, 'InvalidPayload', `condition '${envelope.condition}' args`);
 
     const cacheKey = `${tenantId}:${envelope.condition}:${JSON.stringify(envelope.args)}`;

--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -223,6 +223,31 @@ export function createBroker({
     }
   }
 
+  /**
+   * F4 — `subscribe()` was completely unauthorized: any MP could subscribe to
+   * any trigger and receive its payload (passive cross-MP exfiltration).
+   * Subscription is a REGISTRATION, not an RPC — there is no envelope and no
+   * capability token on this path — so the grant is read from the subscriber's
+   * REGISTERED MANIFEST `permissions.scopes`, the same list the host mints its
+   * tokens from. Trigger ownership is the other way through, mirroring the
+   * same-MP exemption used by invoke/query.
+   *
+   * Shares `strictEmitOwnership` with F3: emit-side and subscribe-side trigger
+   * authority land (and flip) together.
+   */
+  function authorizeSubscribe(subscriberMpId, triggerQualified) {
+    if (!strictEmitOwnership) return;
+    const [ownerMpId] = splitQualified(triggerQualified);
+    if (ownerMpId === subscriberMpId) return; // an MP always hears its own triggers
+    const declared = mps.get(subscriberMpId)?.manifest.permissions?.scopes || [];
+    const scope = `read:${triggerQualified}`;
+    if (!declared.includes(scope) && !declared.includes('*')) {
+      throw err('PermissionDenied', `mp '${subscriberMpId}' lacks scope '${scope}' to subscribe to '${triggerQualified}'`, {
+        rule: 'permissions', retryable: false,
+      });
+    }
+  }
+
   // --- Active Trigger Index (D21) -------------------------------------------
 
   function actionKey(tenantId, mpId, actionId) { return `${tenantId}:${mpId}:${actionId}`; }
@@ -404,6 +429,23 @@ export function createBroker({
     const ownerEntry = mps.get(ownerMpId);
     const triggerDef = ownerEntry?.manifest.triggers?.[triggerName];
     if (!triggerDef) throw err('UnknownTrigger', `trigger '${triggerQualified}' is not declared by any registered MP`, { retryable: false });
+
+    // F3 — owner assert. The owner is resolved from the trigger STRING and was
+    // never checked against the emitter, so any MP could emit
+    // `time-clock.shift_marked_absent` (or `scheduling.shift_assigned`) and
+    // drive another MP's Actions. EXEMPT: the platform-emit / host-injection
+    // intake — those envelopes are authenticated at the socket boundary and
+    // carry a host-supplied `identity` with NO capability token, legitimately
+    // emitting on the owning MP's behalf (tommy-app mp-loader/platform-emit.js).
+    // Asserted BEFORE the offline enqueue, so a queued emit is checked once at
+    // enqueue and its drain (which replays with `identity` attached) is not
+    // re-judged.
+    const hostOriginated = !envelope.capabilityToken && !!envelope.identity;
+    if (strictEmitOwnership && ownerMpId !== emitterMp && !hostOriginated) {
+      throw err('PermissionDenied', `mp '${emitterMp}' may not emit '${triggerQualified}' — the trigger is owned by '${ownerMpId}'`, {
+        rule: 'triggers.owner', retryable: false,
+      });
+    }
     validateAgainst(triggerDef.payloadSchema, envelope.payload, 'InvalidPayload', `trigger '${triggerQualified}' payload`);
 
     // D21 emit-side short-circuit: no enabled consumer -> suppress (tally only).
@@ -812,6 +854,7 @@ export function createBroker({
 
     subscribe(mpId, trigger, handler) {
       const qualified = trigger.includes('.') ? trigger : qualify(mpId, trigger);
+      authorizeSubscribe(mpId, qualified);
       const set = subscribers.get(qualified) || new Set();
       const entry = { mpId, handler };
       set.add(entry);

--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -22,7 +22,10 @@
 import { TommyError, isTommyError } from '@tommy/sdk';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import { DEFAULT_THROTTLE_PROFILE, QUEUE_MAX_ENTRIES, QUEUE_MAX_BYTES, SYNC_EMIT_TIMEOUT_MS, DEFAULT_RETRY } from './constants.js';
+import {
+  DEFAULT_THROTTLE_PROFILE, QUEUE_MAX_ENTRIES, QUEUE_MAX_BYTES, SYNC_EMIT_TIMEOUT_MS, DEFAULT_RETRY,
+  SENSITIVE_CONDITIONS, domainScopeForMp,
+} from './constants.js';
 import { createRecordStore } from './records.js';
 import { validateToken } from './capability.js';
 
@@ -76,6 +79,10 @@ export function createBroker({
   enforceConditionScopes = false,
   /** F3/F4: emit must own the trigger namespace; subscribe must be granted. */
   strictEmitOwnership = false,
+  /** C1/Option B: `{ mpId: 'domain' }` overrides for read-scope derivation. */
+  domainScopeOverrides = {},
+  /** C1/Option B: primitives derivation must not grant (defaults to the exported set). */
+  sensitiveConditions = SENSITIVE_CONDITIONS,
 } = {}) {
   if (!capabilityService || typeof capabilityService.validate !== 'function') {
     throw new Error('createBroker: capabilityService with validate() required');
@@ -202,24 +209,64 @@ export function createBroker({
     }
   }
 
+  const isSensitive = (qualified) => (typeof sensitiveConditions?.has === 'function'
+    ? sensitiveConditions.has(qualified)
+    : (sensitiveConditions || []).includes(qualified));
+
+  /**
+   * Shared read-grant test for F2 (conditions) and F4 (triggers) — council C1
+   * resolved to DERIVED scopes (Option B). A read of `{owner}.{primitive}` is
+   * granted by ANY of:
+   *
+   *   1. the explicit per-primitive scope `read:{owner}.{primitive}` — mirrors
+   *      the invoke convention (`invoke:{owner}.{activity}`) and stays valid as
+   *      a strict superset of the derived form;
+   *   2. the owner's DOMAIN scope from the fixed catalogue (`read:shifts` for
+   *      scheduling, `read:attendance` for time-clock, …) — the vocabulary the
+   *      manifests already declare, so most of the estate needs no new
+   *      declaration at all;
+   *   3. '*', the HOST authority marker (inspector replay, txn compensation) —
+   *      never issuable to an MP through a capability token.
+   *
+   * EXCEPT for SENSITIVE_CONDITIONS, where (2) does not apply: those demand the
+   * explicit per-primitive scope. Holding `read:attendance` must not hand a
+   * caller `time-clock.kiosk_pin`.
+   */
+  function readGrant(ownerMpId, primitiveName) {
+    const qualified = qualify(ownerMpId, primitiveName);
+    const explicit = `read:${qualified}`;
+    const domain = domainScopeForMp(ownerMpId, domainScopeOverrides);
+    const sensitive = isSensitive(qualified);
+    return {
+      qualified,
+      explicit,
+      domain,
+      sensitive,
+      // The scopes that would grant this read, most specific first.
+      accepts: sensitive ? [explicit] : [explicit, domain],
+      denialMessage: sensitive
+        ? `caller lacks scope '${explicit}' ('${qualified}' is sensitive — the '${domain}' domain scope does not grant it)`
+        : `caller lacks scope '${explicit}' or '${domain}'`,
+    };
+  }
+
+  const holdsReadGrant = (held, grant) => grant.accepts.some((s) => held.includes(s)) || held.includes('*');
+
   /**
    * F2 — condition reads were unmediated: no authz, no scope, no equivalent of
    * `authorizeInvoke`, so any MP could read any other MP's conditions
-   * (kiosk PINs, vendor settings, client records). The scope name MIRRORS the
-   * invoke convention exactly — `read:{ownerMpId}.{conditionName}` where
-   * invoke uses `invoke:{ownerMpId}.{activityName}` — including the '*' host
-   * authority marker and the same-MP (callerIsTarget) exemption.
+   * (kiosk PINs, vendor settings, client records). Grant resolution per
+   * `readGrant` above; the same-MP (callerIsTarget) exemption mirrors invoke.
    *
-   * Gated on `enforceConditionScopes` (default OFF): no manifest declares a
-   * `read:` scope for a cross-MP condition yet.
+   * Gated on `enforceConditionScopes` (default OFF) until the last callers
+   * declare their owner-domain scopes (HANDOFF-m1-grants.md §A).
    */
   function authorizeQuery(callerMpId, ownerMpId, conditionName, scopes) {
     if (!enforceConditionScopes) return;
     if (callerMpId === ownerMpId) return; // an MP always reads its own conditions
-    const scope = `read:${qualify(ownerMpId, conditionName)}`;
-    const held = scopes || [];
-    if (!held.includes(scope) && !held.includes('*')) {
-      throw err('PermissionDenied', `caller lacks scope '${scope}'`, { rule: 'permissions', retryable: false });
+    const grant = readGrant(ownerMpId, conditionName);
+    if (!holdsReadGrant(scopes || [], grant)) {
+      throw err('PermissionDenied', grant.denialMessage, { rule: 'permissions', retryable: false });
     }
   }
 
@@ -228,21 +275,24 @@ export function createBroker({
    * any trigger and receive its payload (passive cross-MP exfiltration).
    * Subscription is a REGISTRATION, not an RPC — there is no envelope and no
    * capability token on this path — so the grant is read from the subscriber's
-   * REGISTERED MANIFEST `permissions.scopes`, the same list the host mints its
-   * tokens from. Trigger ownership is the other way through, mirroring the
-   * same-MP exemption used by invoke/query.
+   * REGISTERED MANIFEST `permissions.scopes` — which, under council C1's
+   * derived-scope resolution, is exactly the vocabulary that list already
+   * speaks: the owner's catalogue DOMAIN scope grants its triggers, with the
+   * explicit per-primitive form still accepted and SENSITIVE_CONDITIONS still
+   * excluded from derivation. Trigger ownership is the other way through,
+   * mirroring the same-MP exemption used by invoke/query.
    *
    * Shares `strictEmitOwnership` with F3: emit-side and subscribe-side trigger
    * authority land (and flip) together.
    */
   function authorizeSubscribe(subscriberMpId, triggerQualified) {
     if (!strictEmitOwnership) return;
-    const [ownerMpId] = splitQualified(triggerQualified);
+    const [ownerMpId, triggerName] = splitQualified(triggerQualified);
     if (ownerMpId === subscriberMpId) return; // an MP always hears its own triggers
     const declared = mps.get(subscriberMpId)?.manifest.permissions?.scopes || [];
-    const scope = `read:${triggerQualified}`;
-    if (!declared.includes(scope) && !declared.includes('*')) {
-      throw err('PermissionDenied', `mp '${subscriberMpId}' lacks scope '${scope}' to subscribe to '${triggerQualified}'`, {
+    const grant = readGrant(ownerMpId, triggerName);
+    if (!holdsReadGrant(declared, grant)) {
+      throw err('PermissionDenied', `mp '${subscriberMpId}' may not subscribe to '${triggerQualified}': ${grant.denialMessage}`, {
         rule: 'permissions', retryable: false,
       });
     }

--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -666,7 +666,14 @@ export function createBroker({
     if (chain.rootRunId) checkChain(envelope.sourceMpId, `invoke(${envelope.activity})`, chain);
 
     const idempotencyKey = idempotencyKeyFor(activityDef, envelope);
-    const processedKey = idempotencyKey && `${envelope.activity}:${idempotencyKey}`;
+    // F5 — TENANT-SCOPED. The ledger key used to be (activity, key) only, and
+    // `derived_from_input` keys are a hash of the args alone, so the same
+    // logical write in two tenants collided and the second replayed the
+    // first tenant's stored result. Mirrors conditionCache/suppressionTally,
+    // which were already tenant-scoped. `processedKeys` lives only for the
+    // lifetime of this broker (no persistence, and the offline queue stores
+    // ENVELOPES, not ledger keys), so the format change replays nothing.
+    const processedKey = idempotencyKey && `${tenantId}:${envelope.activity}:${idempotencyKey}`;
     if (processedKey && processedKeys.has(processedKey)) {
       // Repeat key -> stored prior result, not re-applied (§3.2).
       return { ...processedKeys.get(processedKey), idempotentReplay: true };

--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -67,6 +67,15 @@ export function createBroker({
   now = () => Date.now(),
   online = true,
   throttleOverrides = {},
+  // --- enforcement flags (Class F). Default OFF: turning one ON requires the
+  // matching manifest declarations to exist first (grants / read: scopes), so
+  // each flips in its own wave once the estate declares them. ---
+  /** F1: treat `authorizedCallers: []` as deny-all-cross-MP, not "unset". */
+  strictEmptyCallers = false,
+  /** F2: cross-MP condition reads require a `read:<owner>.<condition>` scope. */
+  enforceConditionScopes = false,
+  /** F3/F4: emit must own the trigger namespace; subscribe must be granted. */
+  strictEmitOwnership = false,
 } = {}) {
   if (!capabilityService || typeof capabilityService.validate !== 'function') {
     throw new Error('createBroker: capabilityService with validate() required');
@@ -165,9 +174,20 @@ export function createBroker({
     const callers = activityDef.authorizedCallers;
     const callerIsTarget = callerMpId === targetMpId;
     const callerFirstParty = mps.get(callerMpId)?.firstParty === true;
+    // Three distinct cases (F1 — they used to be two):
+    //  - non-empty list  -> that list (plus the owner itself)
+    //  - EXPLICIT []     -> the author said "nobody may call this cross-MP";
+    //                       only the owner. Gated on `strictEmptyCallers`
+    //                       because 52 live activities declare [] today and
+    //                       first-party callers rely on the old reading.
+    //  - unset           -> first-party default (NOT default-deny: any
+    //                       registered first-party MP may call it).
+    const explicitEmpty = Array.isArray(callers) && callers.length === 0;
     const allowed = Array.isArray(callers) && callers.length
       ? callers.includes(callerMpId) || callerIsTarget
-      : callerIsTarget || callerFirstParty; // default-deny: first-party + same-MP only
+      : (explicitEmpty && strictEmptyCallers)
+        ? callerIsTarget
+        : callerIsTarget || callerFirstParty;
     if (!allowed) {
       throw err('PermissionDenied', `activity '${qualify(targetMpId, activityName)}' does not list '${callerMpId}' in authorizedCallers`, {
         rule: `activities.${activityName}.authorizedCallers`,

--- a/packages/actions-runtime/src/broker.js
+++ b/packages/actions-runtime/src/broker.js
@@ -92,6 +92,7 @@ export function createBroker({
   const suppressionTally = new Map(); // `${tenantId}:${trigger}:${day}` -> count
   const debouncePending = new Map();  // `${trigger}:${emitterMpId}` -> {timer, resolvers}
   const invokeChains = new Map();     // sourceMpId -> tail promise (FIFO per source MP)
+  const executingChains = new Map();  // sourceMpId -> depth of handler execution ON that chain (F6)
   const txnSteps = new Map();         // txnId -> [{activity, args, idempotencyKey}]
   const chainBudget = new Map();      // rootRunId -> total run count
   const buckets = new Map();          // `${mpId}:${kind}` -> {tokens, updatedAt}
@@ -533,8 +534,26 @@ export function createBroker({
     return { rpcId: record.runId, status: 'succeeded', result };
   }
 
+  /**
+   * F6 — re-entrancy. The chain for `mpId` is "executing" for exactly as long
+   * as one of its dispatches is inside an activity handler/executor. A nested
+   * invoke can only be issued from THERE (handler code calling
+   * `tommy.actions.invoke` again), so an invoke that arrives while its own
+   * chain is executing is a descendant of the dispatch holding the chain —
+   * queueing it behind that dispatch is a guaranteed deadlock. It runs INLINE
+   * on the running chain instead, which is also the correct ordering: the
+   * ancestor is, by construction, still ahead of it.
+   */
+  function enterExecution(mpId) { executingChains.set(mpId, (executingChains.get(mpId) || 0) + 1); }
+  function exitExecution(mpId) {
+    const depth = (executingChains.get(mpId) || 0) - 1;
+    if (depth > 0) executingChains.set(mpId, depth); else executingChains.delete(mpId);
+  }
+
   async function dispatchInvoke(envelope) {
     const sourceMpId = envelope.sourceMpId;
+    // Re-entrant (nested) dispatch: run inline, never behind our own ancestor.
+    if (executingChains.has(sourceMpId)) return dispatchInvokeInner(envelope);
     // FIFO per source MP (§3.3): chain this dispatch after the previous one.
     const tail = invokeChains.get(sourceMpId) || Promise.resolve();
     const run = tail.catch(() => {}).then(() => dispatchInvokeInner(envelope));
@@ -616,7 +635,15 @@ export function createBroker({
       attempt += 1;
       await records.update(record.runId, { status: 'running', attempts: attempt });
       try {
-        const result = await executeInvoke(envelope, activityDef, ownerEntry, ownerMpId, activityName, record);
+        // The handler window IS the re-entrancy window (F6): a nested invoke
+        // can only originate from inside it.
+        enterExecution(envelope.sourceMpId);
+        let result;
+        try {
+          result = await executeInvoke(envelope, activityDef, ownerEntry, ownerMpId, activityName, record);
+        } finally {
+          exitExecution(envelope.sourceMpId);
+        }
         if (result.status && result.status === 'failed') throw err('ActivityFailed', result.error?.message || 'executor reported failure', { retryable: false });
         validateAgainst(activityDef.resultSchema, result.result, 'ActivityFailed', `activity '${envelope.activity}' result`);
         const final = { rpcId: record.runId, status: 'succeeded', result: result.result };

--- a/packages/actions-runtime/src/constants.js
+++ b/packages/actions-runtime/src/constants.js
@@ -25,3 +25,51 @@ export const SYNC_EMIT_TIMEOUT_MS = 3000;
 
 /** Default retry budget when an activity declares none. */
 export const DEFAULT_RETRY = Object.freeze({ maxAttempts: 3, backoff: 'exponential' });
+
+/**
+ * Read-scope DERIVATION map (council C1 / Option B).
+ *
+ * The fixed permission catalogue (@tommy/manifest
+ * src/catalogue/permission-catalogue.json) speaks in DOMAINS — `read:shifts`,
+ * `read:attendance` — while the broker's cross-MP checks name PRIMITIVES —
+ * `read:{owner}.{condition}`. Option B derives the second from the first: an
+ * MP holding the owner's domain scope may read that owner's conditions and
+ * subscribe to its triggers, with no new catalogue members and no per-primitive
+ * minting. Explicit per-primitive scopes remain valid (a strict superset), and
+ * SENSITIVE_CONDITIONS below opts individual primitives OUT of derivation.
+ *
+ * Only MPs whose catalogue domain differs from their id are listed; everything
+ * else derives `read:{mpId with - → _}` (see `domainScopeForMp`). MPs whose
+ * fallback is not yet a catalogue member (care-plans, calendar, onboarding)
+ * are therefore reachable only via an explicit per-primitive scope until the
+ * catalogue grows — deliberate, and tracked in HANDOFF-m1-grants.md §A.
+ */
+export const DOMAIN_SCOPE_BY_MP = Object.freeze({
+  scheduling: 'shifts',
+  'time-clock': 'attendance',
+  invoicing: 'invoices',
+  team: 'team_members',
+  'team-comms': 'messages',
+});
+
+/** `mpId` → the catalogue domain read-scope that covers it. */
+export function domainScopeForMp(mpId, overrides = {}) {
+  const domain = overrides[mpId] || DOMAIN_SCOPE_BY_MP[mpId] || String(mpId).replace(/-/g, '_');
+  return `read:${domain}`;
+}
+
+/**
+ * Primitives that domain derivation must NEVER grant (council C1 / Option B,
+ * part 2). A caller needs the EXPLICIT `read:{owner}.{primitive}` scope for
+ * these even with the enforcement flags on — holding `read:attendance` does
+ * not hand you the kiosk PIN. Keyed `{ownerMpId}.{primitiveName}`; exported so
+ * review tooling and tests read the same list the broker enforces.
+ *
+ * Growing it is a REVIEW decision, not a code convenience: each entry is a
+ * primitive whose payload is a credential, a financial secret, or otherwise
+ * outside its own domain's normal read sensitivity.
+ */
+export const SENSITIVE_CONDITIONS = Object.freeze(new Set([
+  'time-clock.kiosk_pin',      // device kiosk credential
+  'invoicing.vendor_settings', // payment/vendor configuration
+]));

--- a/packages/actions-runtime/src/constants.js
+++ b/packages/actions-runtime/src/constants.js
@@ -40,9 +40,11 @@ export const DEFAULT_RETRY = Object.freeze({ maxAttempts: 3, backoff: 'exponenti
  *
  * Only MPs whose catalogue domain differs from their id are listed; everything
  * else derives `read:{mpId with - → _}` (see `domainScopeForMp`). MPs whose
- * fallback is not yet a catalogue member (care-plans, calendar, onboarding)
- * are therefore reachable only via an explicit per-primitive scope until the
- * catalogue grows — deliberate, and tracked in HANDOFF-m1-grants.md §A.
+ * fallback is not yet a catalogue member (calendar, onboarding) are therefore
+ * reachable only via an explicit per-primitive scope until the catalogue
+ * grows — deliberate, and tracked in HANDOFF-m1-grants.md §A. `care-plans`
+ * left that list in catalogue 0.3.0-starter, which added `read:care_plans`
+ * for invoicing's three NDIS reads.
  */
 export const DOMAIN_SCOPE_BY_MP = Object.freeze({
   scheduling: 'shifts',

--- a/packages/actions-runtime/src/index.js
+++ b/packages/actions-runtime/src/index.js
@@ -7,4 +7,7 @@ export { createRecordStore, createMemoryBackend } from './records.js';
 export { validateToken, createFakeIssuer } from './capability.js';
 export {
   DEFAULT_THROTTLE_PROFILE, QUEUE_MAX_ENTRIES, QUEUE_MAX_BYTES, SYNC_EMIT_TIMEOUT_MS,
+  // Read-scope derivation (council C1 / Option B) — exported so review tooling
+  // and tests read the same lists the broker enforces.
+  DOMAIN_SCOPE_BY_MP, SENSITIVE_CONDITIONS, domainScopeForMp,
 } from './constants.js';

--- a/packages/actions-runtime/test/authz-invoke.test.js
+++ b/packages/actions-runtime/test/authz-invoke.test.js
@@ -1,0 +1,134 @@
+/**
+ * authz-invoke.test.js (F1) — `authorizedCallers: []` means DENY ALL cross-MP,
+ * not "unset". Gap register Class F/F1: the authz ternary collapsed the empty
+ * array into the unset branch, so 52 activities that declare `[]` (all of
+ * time-clock's, timesheets', scheduling's) were callable by any first-party MP.
+ *
+ * The strict reading lands behind `strictEmptyCallers` (default OFF) because
+ * the live estate has cross-MP callers that must first be granted explicitly.
+ * Both flag states are asserted here, plus the first-party default path the
+ * register flags as untested.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBroker, createFakeIssuer } from '../src/index.js';
+
+const TENANT = 'team-1';
+
+const activity = (extra = {}) => ({
+  description: 'a',
+  inputSchema: { type: 'object' },
+  sideEffect: 'local_write',
+  idempotency: 'none',
+  offlineReplayable: false,
+  retry: { maxAttempts: 1 },
+  ...extra,
+});
+
+const manifest = (id, publisherType, activities) => ({
+  id,
+  version: '1.0.0',
+  publisher: { type: publisherType },
+  triggers: {},
+  conditions: {},
+  activities,
+  actions: {},
+});
+
+/**
+ * time-clock owns three activities: one with an EXPLICIT empty caller list,
+ * one with no list at all, one with a non-empty list. timesheets (first party)
+ * and acme (third party) are the callers.
+ */
+async function world({ strictEmptyCallers } = {}) {
+  const issuer = createFakeIssuer();
+  const broker = createBroker({ capabilityService: issuer, strictEmptyCallers });
+  broker.registerMp(manifest('time-clock', 'first_party', {
+    delete_attendance: activity({ authorizedCallers: [] }),
+    touch_attendance: activity(),
+    record_view: activity({ authorizedCallers: ['timesheets'] }),
+  }), {
+    handlers: {
+      activities: {
+        delete_attendance: () => ({ deleted: true }),
+        touch_attendance: () => ({ touched: true }),
+        record_view: () => ({ recorded: true }),
+      },
+    },
+  });
+  broker.registerMp(manifest('timesheets', 'first_party', {}), { handlers: {} });
+  broker.registerMp(manifest('acme-reporting', 'third_party', {}), { handlers: {} });
+
+  const scopes = ['invoke:time-clock.delete_attendance', 'invoke:time-clock.touch_attendance', 'invoke:time-clock.record_view'];
+  const firstPartyToken = await issuer.issue('timesheets', '1.0.0', TENANT, scopes, 'i-ts');
+  const thirdPartyToken = await issuer.issue('acme-reporting', '1.0.0', TENANT, scopes, 'i-acme');
+  const ownerToken = await issuer.issue('time-clock', '1.0.0', TENANT, [], 'i-tc');
+
+  const call = (mpId, instanceId, capabilityToken, name) => broker.invoke({
+    sourceMpId: mpId, instanceId, capabilityToken, activity: `time-clock.${name}`, args: {},
+  });
+  return {
+    broker,
+    asFirstParty: (name) => call('timesheets', 'i-ts', firstPartyToken, name),
+    asThirdParty: (name) => call('acme-reporting', 'i-acme', thirdPartyToken, name),
+    asOwner: (name) => call('time-clock', 'i-tc', ownerToken, name),
+  };
+}
+
+describe('authorizeInvoke — empty vs unset authorizedCallers (F1)', () => {
+  it('strictEmptyCallers ON: [] denies a FIRST-PARTY cross-MP caller', async () => {
+    const w = await world({ strictEmptyCallers: true });
+    const rejection = await w.asFirstParty('delete_attendance').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.rule).toBe('activities.delete_attendance.authorizedCallers');
+  });
+
+  it('strictEmptyCallers ON: [] still allows the OWNING MP (callerIsTarget)', async () => {
+    const w = await world({ strictEmptyCallers: true });
+    const receipt = await w.asOwner('delete_attendance');
+    expect(receipt.result).toEqual({ deleted: true });
+  });
+
+  it('strictEmptyCallers OFF (default): [] preserves the current first-party allow', async () => {
+    const w = await world();
+    const receipt = await w.asFirstParty('delete_attendance');
+    expect(receipt.result).toEqual({ deleted: true });
+  });
+
+  it('UNSET authorizedCallers is unchanged by the flag — first-party default allow', async () => {
+    const off = await world();
+    const on = await world({ strictEmptyCallers: true });
+    expect((await off.asFirstParty('touch_attendance')).result).toEqual({ touched: true });
+    expect((await on.asFirstParty('touch_attendance')).result).toEqual({ touched: true });
+  });
+
+  it('UNSET authorizedCallers denies a THIRD-PARTY caller under both flag states', async () => {
+    for (const w of [await world(), await world({ strictEmptyCallers: true })]) {
+      // eslint-disable-next-line no-await-in-loop
+      const rejection = await w.asThirdParty('touch_attendance').catch((e) => e);
+      expect(rejection.code).toBe('PermissionDenied');
+      expect(rejection.rule).toBe('activities.touch_attendance.authorizedCallers');
+    }
+  });
+
+  it('a NON-EMPTY list is unchanged by the flag (listed allowed, unlisted denied)', async () => {
+    const w = await world({ strictEmptyCallers: true });
+    expect((await w.asFirstParty('record_view')).result).toEqual({ recorded: true });
+    const rejection = await w.asThirdParty('record_view').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+  });
+
+  it('an authorised caller still needs the invoke: scope', async () => {
+    const issuer = createFakeIssuer();
+    const broker = createBroker({ capabilityService: issuer, strictEmptyCallers: true });
+    broker.registerMp(manifest('time-clock', 'first_party', { record_view: activity({ authorizedCallers: ['timesheets'] }) }), {
+      handlers: { activities: { record_view: () => ({ recorded: true }) } },
+    });
+    broker.registerMp(manifest('timesheets', 'first_party', {}), { handlers: {} });
+    const scopeless = await issuer.issue('timesheets', '1.0.0', TENANT, [], 'i-ts');
+    const rejection = await broker.invoke({
+      sourceMpId: 'timesheets', instanceId: 'i-ts', capabilityToken: scopeless, activity: 'time-clock.record_view', args: {},
+    }).catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.message).toContain("lacks scope 'invoke:time-clock.record_view'");
+  });
+});

--- a/packages/actions-runtime/test/authz-query.test.js
+++ b/packages/actions-runtime/test/authz-query.test.js
@@ -1,73 +1,103 @@
 /**
- * authz-query.test.js (F2) — cross-MP condition reads need a `read:` scope.
+ * authz-query.test.js (F2) — cross-MP condition reads need a read grant.
  *
  * Gap register Class F/F2: `dispatchQuery` had no `authorizeInvoke` equivalent,
- * so any MP could read `time-clock.kiosk_pin`, `clients.client`, etc. The scope
- * name mirrors the invoke convention exactly (`read:owner.condition` against
- * `invoke:owner.activity`), including the '*' host marker and the same-MP
- * exemption. Gated on `enforceConditionScopes` (default OFF) until the
- * manifests declare the scopes.
+ * so any MP could read `time-clock.kiosk_pin`, `clients.client`, etc.
+ *
+ * Council C1 resolved the grant vocabulary to Option B — DERIVED scopes:
+ *   - the owner's catalogue DOMAIN scope (`read:attendance` for time-clock,
+ *     `read:shifts` for scheduling) grants that owner's conditions;
+ *   - the explicit per-primitive `read:{owner}.{condition}` still works
+ *     (a strict superset, mirroring `invoke:{owner}.{activity}`);
+ *   - SENSITIVE_CONDITIONS are excluded from derivation — the domain scope
+ *     does NOT grant them, only the explicit per-primitive scope does.
+ * Gated on `enforceConditionScopes` (default OFF).
  */
 import { describe, it, expect } from 'vitest';
-import { createBroker, createFakeIssuer } from '../src/index.js';
+import { createBroker, createFakeIssuer, SENSITIVE_CONDITIONS, DOMAIN_SCOPE_BY_MP, domainScopeForMp } from '../src/index.js';
 
 const TENANT = 'team-1';
 
+const condition = () => ({
+  description: 'c', inputSchema: { type: 'object' }, returnSchema: { type: 'string' }, latencyBudgetMs: 100,
+});
+
+// time-clock's catalogue domain is `attendance`, NOT its own id — the case the
+// derivation map exists for.
 const owner = {
   id: 'time-clock',
   version: '1.0.0',
   publisher: { type: 'first_party' },
   triggers: {},
-  conditions: {
-    kiosk_pin: {
-      description: 'c', inputSchema: { type: 'object' }, returnSchema: { type: 'string' }, latencyBudgetMs: 100,
-    },
-  },
+  conditions: { attendance_history: condition(), kiosk_pin: condition() },
+  activities: {},
+  actions: {},
+};
+
+const otherOwner = {
+  id: 'invoicing',
+  version: '1.0.0',
+  publisher: { type: 'first_party' },
+  triggers: {},
+  conditions: { invoices_list: condition(), vendor_settings: condition() },
   activities: {},
   actions: {},
 };
 
 const caller = {
   id: 'timesheets', version: '1.0.0', publisher: { type: 'first_party' }, triggers: {}, activities: {}, actions: {},
-  conditions: {
-    own_read: {
-      description: 'c', inputSchema: { type: 'object' }, returnSchema: { type: 'string' }, latencyBudgetMs: 100,
-    },
-  },
+  conditions: { own_read: condition() },
 };
 
-async function world({ enforceConditionScopes, scopes = [] } = {}) {
+async function world({ enforceConditionScopes, scopes = [], sensitiveConditions, domainScopeOverrides } = {}) {
   const issuer = createFakeIssuer();
-  const broker = createBroker({ capabilityService: issuer, enforceConditionScopes });
-  broker.registerMp(owner, { handlers: { conditions: { kiosk_pin: () => '1234' } } });
+  const broker = createBroker({
+    capabilityService: issuer, enforceConditionScopes, sensitiveConditions, domainScopeOverrides,
+  });
+  broker.registerMp(owner, { handlers: { conditions: { attendance_history: () => 'hours', kiosk_pin: () => '1234' } } });
+  broker.registerMp(otherOwner, { handlers: { conditions: { invoices_list: () => 'invoices', vendor_settings: () => 'iban' } } });
   broker.registerMp(caller, { handlers: { conditions: { own_read: () => 'mine' } } });
   const token = await issuer.issue('timesheets', '1.0.0', TENANT, scopes, 'i-ts');
   return {
     broker,
-    query: (condition) => broker.query({
-      sourceMpId: 'timesheets', instanceId: 'i-ts', capabilityToken: token, condition, args: {},
+    query: (cond) => broker.query({
+      sourceMpId: 'timesheets', instanceId: 'i-ts', capabilityToken: token, condition: cond, args: {},
     }),
   };
 }
 
 describe('dispatchQuery — condition read scopes (F2)', () => {
-  it('flag OFF (default): a cross-MP read with no read: scope still succeeds', async () => {
+  it('flag OFF (default): a cross-MP read with no scope at all still succeeds', async () => {
     const w = await world();
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
     expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
   });
 
-  it('flag ON: a cross-MP read without the read: scope is PermissionDenied', async () => {
+  it('flag ON: a cross-MP read with neither scope is PermissionDenied', async () => {
     const w = await world({ enforceConditionScopes: true });
-    const rejection = await w.query('time-clock.kiosk_pin').catch((e) => e);
+    const rejection = await w.query('time-clock.attendance_history').catch((e) => e);
     expect(rejection.code).toBe('PermissionDenied');
-    expect(rejection.message).toContain("lacks scope 'read:time-clock.kiosk_pin'");
+    expect(rejection.message).toContain("'read:time-clock.attendance_history'");
+    expect(rejection.message).toContain("'read:attendance'"); // names the derived route too
     expect(rejection.rule).toBe('permissions');
     expect(rejection.retryable).toBe(false);
   });
 
-  it('flag ON: the read: scope grants the cross-MP read', async () => {
-    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.kiosk_pin'] });
-    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
+  it('flag ON: the owner DOMAIN scope grants the read (Option B derivation)', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:attendance'] });
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
+  });
+
+  it('flag ON: the explicit per-primitive scope still grants the read (superset)', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.attendance_history'] });
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
+  });
+
+  it("flag ON: another owner's domain scope does not leak across owners", async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:attendance'] });
+    const rejection = await w.query('invoicing.invoices_list').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.message).toContain("'read:invoices'");
   });
 
   it('flag ON: a same-MP read is exempt (mirrors callerIsTarget on invoke)', async () => {
@@ -75,20 +105,80 @@ describe('dispatchQuery — condition read scopes (F2)', () => {
     expect(await w.query('timesheets.own_read')).toBe('mine');
   });
 
-  it("flag ON: the host authority marker '*' passes (inspector replay / Action gates)", async () => {
+  it("flag ON: the host authority marker '*' passes, sensitive or not", async () => {
     const w = await world({ enforceConditionScopes: true, scopes: ['*'] });
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
     expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
-  });
-
-  it('flag ON: an unrelated read: scope does not grant a different condition', async () => {
-    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.something_else'] });
-    const rejection = await w.query('time-clock.kiosk_pin').catch((e) => e);
-    expect(rejection.code).toBe('PermissionDenied');
   });
 
   it('an unknown condition still fails as UnknownCondition, not PermissionDenied', async () => {
     const w = await world({ enforceConditionScopes: true });
     const rejection = await w.query('time-clock.nope').catch((e) => e);
     expect(rejection.code).toBe('UnknownCondition');
+  });
+});
+
+describe('SENSITIVE_CONDITIONS — derivation does not reach them (C1 part 2)', () => {
+  it('exports the reviewed set for tooling', () => {
+    expect(SENSITIVE_CONDITIONS.has('time-clock.kiosk_pin')).toBe(true);
+    expect(SENSITIVE_CONDITIONS.has('invoicing.vendor_settings')).toBe(true);
+    expect(SENSITIVE_CONDITIONS.has('time-clock.attendance_history')).toBe(false);
+  });
+
+  it('the DOMAIN scope does NOT grant a sensitive condition', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:attendance'] });
+    const rejection = await w.query('time-clock.kiosk_pin').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.message).toContain('is sensitive');
+    expect(rejection.message).toContain("'read:time-clock.kiosk_pin'");
+    // ...while the same scope still grants the non-sensitive sibling.
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
+  });
+
+  it('the EXPLICIT per-primitive scope does grant a sensitive condition', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.kiosk_pin'] });
+    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
+  });
+
+  it('covers the second seeded entry (invoicing.vendor_settings)', async () => {
+    const domainOnly = await world({ enforceConditionScopes: true, scopes: ['read:invoices'] });
+    expect(await domainOnly.query('invoicing.invoices_list')).toBe('invoices');
+    const rejection = await domainOnly.query('invoicing.vendor_settings').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    const explicit = await world({ enforceConditionScopes: true, scopes: ['read:invoicing.vendor_settings'] });
+    expect(await explicit.query('invoicing.vendor_settings')).toBe('iban');
+  });
+
+  it('the set is overridable per broker (review tooling / host policy)', async () => {
+    const w = await world({
+      enforceConditionScopes: true,
+      scopes: ['read:attendance'],
+      sensitiveConditions: new Set(['time-clock.attendance_history']),
+    });
+    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');   // no longer sensitive
+    const rejection = await w.query('time-clock.attendance_history').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');              // now sensitive
+  });
+});
+
+describe('domain-scope derivation map', () => {
+  it('maps the MPs whose catalogue domain differs from their id', () => {
+    expect(DOMAIN_SCOPE_BY_MP.scheduling).toBe('shifts');
+    expect(DOMAIN_SCOPE_BY_MP['time-clock']).toBe('attendance');
+    expect(domainScopeForMp('scheduling')).toBe('read:shifts');
+    expect(domainScopeForMp('time-clock')).toBe('read:attendance');
+  });
+
+  it('falls back to the MP id (dashes normalised) when unmapped', () => {
+    expect(domainScopeForMp('leave')).toBe('read:leave');
+    expect(domainScopeForMp('care-plans')).toBe('read:care_plans');
+  });
+
+  it('accepts host overrides', async () => {
+    expect(domainScopeForMp('calendar', { calendar: 'shifts' })).toBe('read:shifts');
+    const w = await world({
+      enforceConditionScopes: true, scopes: ['read:timekeeping'], domainScopeOverrides: { 'time-clock': 'timekeeping' },
+    });
+    expect(await w.query('time-clock.attendance_history')).toBe('hours');
   });
 });

--- a/packages/actions-runtime/test/authz-query.test.js
+++ b/packages/actions-runtime/test/authz-query.test.js
@@ -1,0 +1,94 @@
+/**
+ * authz-query.test.js (F2) — cross-MP condition reads need a `read:` scope.
+ *
+ * Gap register Class F/F2: `dispatchQuery` had no `authorizeInvoke` equivalent,
+ * so any MP could read `time-clock.kiosk_pin`, `clients.client`, etc. The scope
+ * name mirrors the invoke convention exactly (`read:owner.condition` against
+ * `invoke:owner.activity`), including the '*' host marker and the same-MP
+ * exemption. Gated on `enforceConditionScopes` (default OFF) until the
+ * manifests declare the scopes.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBroker, createFakeIssuer } from '../src/index.js';
+
+const TENANT = 'team-1';
+
+const owner = {
+  id: 'time-clock',
+  version: '1.0.0',
+  publisher: { type: 'first_party' },
+  triggers: {},
+  conditions: {
+    kiosk_pin: {
+      description: 'c', inputSchema: { type: 'object' }, returnSchema: { type: 'string' }, latencyBudgetMs: 100,
+    },
+  },
+  activities: {},
+  actions: {},
+};
+
+const caller = {
+  id: 'timesheets', version: '1.0.0', publisher: { type: 'first_party' }, triggers: {}, activities: {}, actions: {},
+  conditions: {
+    own_read: {
+      description: 'c', inputSchema: { type: 'object' }, returnSchema: { type: 'string' }, latencyBudgetMs: 100,
+    },
+  },
+};
+
+async function world({ enforceConditionScopes, scopes = [] } = {}) {
+  const issuer = createFakeIssuer();
+  const broker = createBroker({ capabilityService: issuer, enforceConditionScopes });
+  broker.registerMp(owner, { handlers: { conditions: { kiosk_pin: () => '1234' } } });
+  broker.registerMp(caller, { handlers: { conditions: { own_read: () => 'mine' } } });
+  const token = await issuer.issue('timesheets', '1.0.0', TENANT, scopes, 'i-ts');
+  return {
+    broker,
+    query: (condition) => broker.query({
+      sourceMpId: 'timesheets', instanceId: 'i-ts', capabilityToken: token, condition, args: {},
+    }),
+  };
+}
+
+describe('dispatchQuery — condition read scopes (F2)', () => {
+  it('flag OFF (default): a cross-MP read with no read: scope still succeeds', async () => {
+    const w = await world();
+    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
+  });
+
+  it('flag ON: a cross-MP read without the read: scope is PermissionDenied', async () => {
+    const w = await world({ enforceConditionScopes: true });
+    const rejection = await w.query('time-clock.kiosk_pin').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.message).toContain("lacks scope 'read:time-clock.kiosk_pin'");
+    expect(rejection.rule).toBe('permissions');
+    expect(rejection.retryable).toBe(false);
+  });
+
+  it('flag ON: the read: scope grants the cross-MP read', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.kiosk_pin'] });
+    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
+  });
+
+  it('flag ON: a same-MP read is exempt (mirrors callerIsTarget on invoke)', async () => {
+    const w = await world({ enforceConditionScopes: true });
+    expect(await w.query('timesheets.own_read')).toBe('mine');
+  });
+
+  it("flag ON: the host authority marker '*' passes (inspector replay / Action gates)", async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['*'] });
+    expect(await w.query('time-clock.kiosk_pin')).toBe('1234');
+  });
+
+  it('flag ON: an unrelated read: scope does not grant a different condition', async () => {
+    const w = await world({ enforceConditionScopes: true, scopes: ['read:time-clock.something_else'] });
+    const rejection = await w.query('time-clock.kiosk_pin').catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+  });
+
+  it('an unknown condition still fails as UnknownCondition, not PermissionDenied', async () => {
+    const w = await world({ enforceConditionScopes: true });
+    const rejection = await w.query('time-clock.nope').catch((e) => e);
+    expect(rejection.code).toBe('UnknownCondition');
+  });
+});

--- a/packages/actions-runtime/test/authz-trigger.test.js
+++ b/packages/actions-runtime/test/authz-trigger.test.js
@@ -1,0 +1,126 @@
+/**
+ * authz-trigger.test.js (F3 + F4) — trigger authority, both directions.
+ *
+ * F3: the emitter must own the trigger namespace. The broker resolved the
+ *     owner from the trigger string and never asserted it, so any MP could
+ *     emit `time-clock.shift_marked_absent` and drive another MP's Action.
+ *     The platform-emit / host-injection intake is exempt.
+ * F4: subscribing was entirely unauthorized — passive cross-MP exfiltration.
+ *     A cross-MP subscription now needs the trigger owner's `read:` scope in
+ *     the subscriber's declared manifest permissions.
+ *
+ * Both ride `strictEmitOwnership` (default OFF) — the manifests declare no
+ * `read:` trigger scopes yet.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBroker, createFakeIssuer } from '../src/index.js';
+
+const TENANT = 'team-1';
+
+const trigger = () => ({ description: 't', payloadSchema: { type: 'object' }, emission: 'async' });
+
+const mp = (id, { triggers = {}, scopes } = {}) => ({
+  id,
+  version: '1.0.0',
+  publisher: { type: 'first_party' },
+  triggers,
+  conditions: {},
+  activities: {},
+  actions: {},
+  ...(scopes ? { permissions: { scopes } } : {}),
+});
+
+async function world({ strictEmitOwnership, subscriberScopes } = {}) {
+  const issuer = createFakeIssuer();
+  const broker = createBroker({ capabilityService: issuer, strictEmitOwnership });
+  broker.registerMp(mp('time-clock', { triggers: { shift_marked_absent: trigger() } }), { handlers: {} });
+  broker.registerMp(mp('leave', { triggers: { leave_created: trigger() }, scopes: subscriberScopes }), { handlers: {} });
+  const leaveToken = await issuer.issue('leave', '1.0.0', TENANT, [], 'i-leave');
+  return {
+    broker,
+    // 'leave' is the impostor: it emits a trigger that time-clock owns.
+    emitForeign: () => broker.emit({
+      sourceMpId: 'leave', instanceId: 'i-leave', capabilityToken: leaveToken, trigger: 'time-clock.shift_marked_absent', payload: {},
+    }),
+    emitOwn: () => broker.emit({
+      sourceMpId: 'leave', instanceId: 'i-leave', capabilityToken: leaveToken, trigger: 'leave.leave_created', payload: {},
+    }),
+    // What tommy-app's platform-emit intake sends: host identity, no token.
+    emitFromPlatform: () => broker.emit({
+      sourceMpId: 'leave',
+      trigger: 'time-clock.shift_marked_absent',
+      payload: {},
+      identity: { mpId: 'leave', tenantId: TENANT, scopes: [], tokenId: 'platform-e-1' },
+    }),
+    subscribeForeign: () => broker.subscribe('leave', 'time-clock.shift_marked_absent', () => {}),
+    subscribeOwn: () => broker.subscribe('leave', 'leave.leave_created', () => {}),
+    subscribeOwnUnqualified: () => broker.subscribe('leave', 'leave_created', () => {}),
+  };
+}
+
+describe('dispatchEmit — trigger owner assert (F3)', () => {
+  it('flag OFF (default): a foreign-namespace emit still goes through', async () => {
+    const w = await world();
+    const receipt = await w.emitForeign();
+    expect(receipt.suppressed).toBe(true); // no consumer wired — D21 short-circuit
+  });
+
+  it('flag ON: emitting another MP\'s trigger is PermissionDenied', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    const rejection = await w.emitForeign().catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(rejection.rule).toBe('triggers.owner');
+    expect(rejection.message).toContain("owned by 'time-clock'");
+  });
+
+  it('flag ON: emitting your OWN trigger is unaffected', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    const receipt = await w.emitOwn();
+    expect(receipt.suppressed).toBe(true);
+  });
+
+  it('flag ON: the platform-emit / host-injection intake is EXEMPT', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    const receipt = await w.emitFromPlatform();
+    expect(receipt.suppressed).toBe(true);
+    expect(receipt.emitId).toBeTruthy();
+  });
+
+  it('flag ON: the assert runs BEFORE the offline queue (a bad emit never queues)', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    w.broker.setOnline(false);
+    const rejection = await w.emitForeign().catch((e) => e);
+    expect(rejection.code).toBe('PermissionDenied');
+    expect(w.broker.queueStats().total).toBe(0);
+  });
+});
+
+describe('subscribe — trigger read grant (F4)', () => {
+  it('flag OFF (default): a cross-MP subscription is accepted', async () => {
+    const w = await world();
+    expect(typeof w.subscribeForeign()).toBe('function');
+  });
+
+  it('flag ON: a cross-MP subscription without the read: scope is PermissionDenied', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    expect(() => w.subscribeForeign()).toThrow(/lacks scope 'read:time-clock.shift_marked_absent'/);
+  });
+
+  it('flag ON: the declared read: scope grants the subscription', async () => {
+    const w = await world({ strictEmitOwnership: true, subscriberScopes: ['read:time-clock.shift_marked_absent'] });
+    expect(typeof w.subscribeForeign()).toBe('function');
+  });
+
+  it('flag ON: subscribing to your OWN trigger needs no scope (qualified or not)', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    expect(typeof w.subscribeOwn()).toBe('function');
+    expect(typeof w.subscribeOwnUnqualified()).toBe('function');
+  });
+
+  it('flag ON: a denied subscription registers no subscriber (payload never delivered)', async () => {
+    const w = await world({ strictEmitOwnership: true });
+    expect(() => w.subscribeForeign()).toThrow();
+    const receipt = await w.emitFromPlatform();
+    expect(receipt.suppressed).toBe(true); // still no consumer
+  });
+});

--- a/packages/actions-runtime/test/authz-trigger.test.js
+++ b/packages/actions-runtime/test/authz-trigger.test.js
@@ -6,8 +6,11 @@
  *     emit `time-clock.shift_marked_absent` and drive another MP's Action.
  *     The platform-emit / host-injection intake is exempt.
  * F4: subscribing was entirely unauthorized — passive cross-MP exfiltration.
- *     A cross-MP subscription now needs the trigger owner's `read:` scope in
- *     the subscriber's declared manifest permissions.
+ *     A cross-MP subscription now needs a read grant on the trigger, resolved
+ *     the same way F2 resolves condition reads (council C1 / Option B): the
+ *     owner's catalogue DOMAIN scope, or the explicit per-primitive scope, read
+ *     from the subscriber's DECLARED MANIFEST permissions. SENSITIVE_CONDITIONS
+ *     entries are excluded from domain derivation here too.
  *
  * Both ride `strictEmitOwnership` (default OFF) — the manifests declare no
  * `read:` trigger scopes yet.
@@ -30,9 +33,9 @@ const mp = (id, { triggers = {}, scopes } = {}) => ({
   ...(scopes ? { permissions: { scopes } } : {}),
 });
 
-async function world({ strictEmitOwnership, subscriberScopes } = {}) {
+async function world({ strictEmitOwnership, subscriberScopes, sensitiveConditions } = {}) {
   const issuer = createFakeIssuer();
-  const broker = createBroker({ capabilityService: issuer, strictEmitOwnership });
+  const broker = createBroker({ capabilityService: issuer, strictEmitOwnership, sensitiveConditions });
   broker.registerMp(mp('time-clock', { triggers: { shift_marked_absent: trigger() } }), { handlers: {} });
   broker.registerMp(mp('leave', { triggers: { leave_created: trigger() }, scopes: subscriberScopes }), { handlers: {} });
   const leaveToken = await issuer.issue('leave', '1.0.0', TENANT, [], 'i-leave');
@@ -101,14 +104,36 @@ describe('subscribe — trigger read grant (F4)', () => {
     expect(typeof w.subscribeForeign()).toBe('function');
   });
 
-  it('flag ON: a cross-MP subscription without the read: scope is PermissionDenied', async () => {
+  it('flag ON: a cross-MP subscription with no read grant is PermissionDenied', async () => {
     const w = await world({ strictEmitOwnership: true });
-    expect(() => w.subscribeForeign()).toThrow(/lacks scope 'read:time-clock.shift_marked_absent'/);
+    expect(() => w.subscribeForeign()).toThrow(/read:time-clock.shift_marked_absent/);
+    // The denial names the derived route as well as the explicit one.
+    expect(() => w.subscribeForeign()).toThrow(/read:attendance/);
   });
 
-  it('flag ON: the declared read: scope grants the subscription', async () => {
+  it("flag ON: the owner's declared DOMAIN scope grants the subscription (Option B)", async () => {
+    const w = await world({ strictEmitOwnership: true, subscriberScopes: ['read:attendance'] });
+    expect(typeof w.subscribeForeign()).toBe('function');
+  });
+
+  it('flag ON: the explicit per-primitive scope grants the subscription (superset)', async () => {
     const w = await world({ strictEmitOwnership: true, subscriberScopes: ['read:time-clock.shift_marked_absent'] });
     expect(typeof w.subscribeForeign()).toBe('function');
+  });
+
+  it("flag ON: an unrelated owner's domain scope does not grant it", async () => {
+    const w = await world({ strictEmitOwnership: true, subscriberScopes: ['read:shifts', 'read:leave'] });
+    expect(() => w.subscribeForeign()).toThrow(/PermissionDenied|read:attendance/);
+  });
+
+  it('flag ON: a SENSITIVE trigger is excluded from domain derivation', async () => {
+    const sensitiveConditions = new Set(['time-clock.shift_marked_absent']);
+    const domainOnly = await world({ strictEmitOwnership: true, subscriberScopes: ['read:attendance'], sensitiveConditions });
+    expect(() => domainOnly.subscribeForeign()).toThrow(/is sensitive/);
+    const explicit = await world({
+      strictEmitOwnership: true, subscriberScopes: ['read:time-clock.shift_marked_absent'], sensitiveConditions,
+    });
+    expect(typeof explicit.subscribeForeign()).toBe('function');
   });
 
   it('flag ON: subscribing to your OWN trigger needs no scope (qualified or not)', async () => {

--- a/packages/actions-runtime/test/idempotency-tenancy.test.js
+++ b/packages/actions-runtime/test/idempotency-tenancy.test.js
@@ -1,0 +1,88 @@
+/**
+ * idempotency-tenancy.test.js (F5) — the processed-key ledger is per TENANT.
+ *
+ * Gap register Class F/F5: the key was `activity:idempotencyKey`, and a
+ * `derived_from_input` key is a hash of the args alone — so the same write in
+ * two tenants collided and the second caller was handed the FIRST tenant's
+ * stored result instead of its own.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBroker, createFakeIssuer } from '../src/index.js';
+
+const activity = (extra = {}) => ({
+  description: 'a',
+  inputSchema: { type: 'object' },
+  sideEffect: 'local_write',
+  offlineReplayable: false,
+  retry: { maxAttempts: 1 },
+  ...extra,
+});
+
+const manifest = {
+  id: 'timesheets',
+  version: '1.0.0',
+  publisher: { type: 'first_party' },
+  triggers: {},
+  conditions: {},
+  activities: {
+    upsert_derived: activity({ idempotency: 'derived_from_input' }),
+    upsert_client_key: activity({ idempotency: 'client_key' }),
+  },
+  actions: {},
+};
+
+async function world() {
+  const issuer = createFakeIssuer();
+  const broker = createBroker({ capabilityService: issuer });
+  const applied = [];
+  broker.registerMp(manifest, {
+    handlers: {
+      activities: {
+        // The result is TENANT-derived: a leaked replay is visible in the value.
+        upsert_derived: (args, ctx) => { applied.push(ctx.tenantId); return { tenantId: ctx.tenantId, ...args }; },
+        upsert_client_key: (args, ctx) => { applied.push(ctx.tenantId); return { tenantId: ctx.tenantId, ...args }; },
+      },
+    },
+  });
+  const tokenA = await issuer.issue('timesheets', '1.0.0', 'team-A', [], 'i-a');
+  const tokenB = await issuer.issue('timesheets', '1.0.0', 'team-B', [], 'i-b');
+  const call = (token, instanceId, name, args, idempotencyKey) => broker.invoke({
+    sourceMpId: 'timesheets', instanceId, capabilityToken: token, activity: `timesheets.${name}`, args, idempotencyKey,
+  });
+  return {
+    asA: (name, args, key) => call(tokenA, 'i-a', name, args, key),
+    asB: (name, args, key) => call(tokenB, 'i-b', name, args, key),
+    applied,
+  };
+}
+
+describe('processedKeys tenancy (F5)', () => {
+  it('two tenants writing the same derived_from_input args each get their OWN result', async () => {
+    const w = await world();
+    const args = { shiftId: 's-1', hours: 8 };
+    const a = await w.asA('upsert_derived', args);
+    const b = await w.asB('upsert_derived', args);
+    expect(a.result).toEqual({ tenantId: 'team-A', ...args });
+    expect(b.result).toEqual({ tenantId: 'team-B', ...args });
+    expect(b.idempotentReplay).toBeUndefined();
+    expect(w.applied).toEqual(['team-A', 'team-B']); // both actually applied
+  });
+
+  it('two tenants reusing the same client_key are not confused with each other', async () => {
+    const w = await world();
+    const a = await w.asA('upsert_client_key', { n: 1 }, 'k-shared');
+    const b = await w.asB('upsert_client_key', { n: 2 }, 'k-shared');
+    expect(a.result).toEqual({ tenantId: 'team-A', n: 1 });
+    expect(b.result).toEqual({ tenantId: 'team-B', n: 2 });
+  });
+
+  it('within ONE tenant the repeat key still replays the stored result (§3.2)', async () => {
+    const w = await world();
+    const args = { shiftId: 's-1', hours: 8 };
+    const first = await w.asA('upsert_derived', args);
+    const repeat = await w.asA('upsert_derived', args);
+    expect(repeat.idempotentReplay).toBe(true);
+    expect(repeat.result).toEqual(first.result);
+    expect(w.applied).toEqual(['team-A']); // applied ONCE
+  });
+});

--- a/packages/actions-runtime/test/reentrancy.test.js
+++ b/packages/actions-runtime/test/reentrancy.test.js
@@ -1,0 +1,154 @@
+/**
+ * reentrancy.test.js (F6) — the per-source-MP FIFO invoke chain must not
+ * deadlock a NESTED invoke issued from inside a handler the same chain is
+ * currently executing, while still serialising genuinely concurrent callers.
+ *
+ * Gap register Class F / F6: `broker.js` chained EVERY invoke per sourceMpId,
+ * so an activity handler invoking another of its own MP's activities queued
+ * behind its own ancestor and never resolved. That deadlock is the documented
+ * reason two cross-MP writes (availability lock, leave-on-shift) went off-bus.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBroker, createFakeIssuer } from '../src/index.js';
+
+const TENANT = 'team-1';
+
+/** Fails fast instead of hanging the suite when the chain deadlocks. */
+function withTimeout(promise, ms, what) {
+  let timer;
+  const guard = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`DEADLOCK: ${what} did not settle within ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, guard]).finally(() => clearTimeout(timer));
+}
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((r) => { resolve = r; });
+  return { promise, resolve };
+};
+
+const activity = (extra = {}) => ({
+  description: 'a',
+  inputSchema: { type: 'object' },
+  sideEffect: 'local_write',
+  idempotency: 'none',
+  offlineReplayable: false,
+  retry: { maxAttempts: 1 },
+  ...extra,
+});
+
+const manifest = (id, activities) => ({
+  id,
+  version: '1.0.0',
+  publisher: { type: 'first_party' },
+  triggers: {},
+  conditions: {},
+  activities,
+  actions: {},
+});
+
+describe('broker invoke re-entrancy (F6)', () => {
+  it('runs a same-MP nested invoke inline on the running chain', async () => {
+    const issuer = createFakeIssuer();
+    const broker = createBroker({ capabilityService: issuer });
+    const token = await issuer.issue('availability', '1.0.0', TENANT, [], 'i-1');
+    const env = (name, args = {}) => ({
+      sourceMpId: 'availability', instanceId: 'i-1', capabilityToken: token, activity: name, args,
+    });
+
+    broker.registerMp(manifest('availability', {
+      lock_window: activity(),
+      write_lock: activity(),
+    }), {
+      handlers: {
+        activities: {
+          // The outer handler invokes another of its OWN activities — the F6 case.
+          lock_window: async (args) => {
+            const nested = await broker.invoke(env('availability.write_lock', args));
+            return { nested: nested.result };
+          },
+          write_lock: async () => ({ locked: true }),
+        },
+      },
+    });
+
+    const receipt = await withTimeout(
+      broker.invoke(env('availability.lock_window', { date: '2026-08-08' })),
+      1500,
+      'nested same-MP invoke',
+    );
+    expect(receipt.status).toBe('succeeded');
+    expect(receipt.result).toEqual({ nested: { locked: true } });
+  });
+
+  it('still serialises two genuinely concurrent top-level invokes from one MP (FIFO §3.3)', async () => {
+    const issuer = createFakeIssuer();
+    const broker = createBroker({ capabilityService: issuer });
+    const token = await issuer.issue('availability', '1.0.0', TENANT, [], 'i-1');
+    const order = [];
+    const gates = { 1: deferred(), 2: deferred() };
+
+    broker.registerMp(manifest('availability', { slow: activity() }), {
+      handlers: {
+        activities: {
+          slow: async ({ n }) => {
+            order.push(`enter${n}`);
+            await gates[n].promise;
+            order.push(`exit${n}`);
+            return { n };
+          },
+        },
+      },
+    });
+
+    const call = (n) => broker.invoke({
+      sourceMpId: 'availability', instanceId: 'i-1', capabilityToken: token, activity: 'availability.slow', args: { n },
+    });
+    const first = call(1);
+    const second = call(2);
+
+    // Let the first dispatch reach its handler; the second must still be queued.
+    await new Promise((r) => { setTimeout(r, 10); });
+    expect(order).toEqual(['enter1']);
+
+    gates[1].resolve();
+    await withTimeout(first, 1500, 'first concurrent invoke');
+    await new Promise((r) => { setTimeout(r, 10); });
+    expect(order).toEqual(['enter1', 'exit1', 'enter2']);
+
+    gates[2].resolve();
+    await withTimeout(second, 1500, 'second concurrent invoke');
+    expect(order).toEqual(['enter1', 'exit1', 'enter2', 'exit2']);
+  });
+
+  it('leaves cross-MP nesting unaffected (target MP nests on its OWN chain)', async () => {
+    const issuer = createFakeIssuer();
+    const broker = createBroker({ capabilityService: issuer });
+    const callerToken = await issuer.issue('time-clock', '1.0.0', TENANT, ['invoke:timesheets.submit'], 'i-tc');
+    const ownerToken = await issuer.issue('timesheets', '1.0.0', TENANT, [], 'i-ts');
+
+    broker.registerMp(manifest('time-clock', {}), { handlers: {} });
+    broker.registerMp(manifest('timesheets', {
+      submit: activity({ authorizedCallers: ['time-clock'] }),
+      recalc: activity(),
+    }), {
+      handlers: {
+        activities: {
+          submit: async () => {
+            const nested = await broker.invoke({
+              sourceMpId: 'timesheets', instanceId: 'i-ts', capabilityToken: ownerToken, activity: 'timesheets.recalc', args: {},
+            });
+            return { nested: nested.result };
+          },
+          recalc: async () => ({ hours: 8 }),
+        },
+      },
+    });
+
+    const receipt = await withTimeout(broker.invoke({
+      sourceMpId: 'time-clock', instanceId: 'i-tc', capabilityToken: callerToken, activity: 'timesheets.submit', args: {},
+    }), 1500, 'cross-MP nested invoke');
+    expect(receipt.result).toEqual({ nested: { hours: 8 } });
+  });
+});

--- a/packages/manifest/src/catalogue/permission-catalogue.embedded.js
+++ b/packages/manifest/src/catalogue/permission-catalogue.embedded.js
@@ -4,10 +4,10 @@
 // or JSON import attributes.
 export default {
   "_comment": "VENDORED FROM plans/refactor-plan/05-deliverables/02-manifest-tooling/permission-catalogue.sample.json — this copy is the runtime source of truth shipped inside @tommy/manifest (a pinned @tommy/manifest version = a pinned catalogue version). The catalogue is FIXED and versioned (Phase 3 Q2) — MPs may only request scopes that appear here; @tommy/manifest validate layer 3 rejects any non-member with the named rule 'permission-not-in-catalogue'. This is the M1 STARTER set (covers every scope the reference manifest uses); the EXHAUSTIVE production catalogue is a deliberate, reviewed Tommy authoring task before M4 (README:68, security-model.md §2) — NOT an M1 gate. Growing it: add entries here, bump catalogueVersion, review. Scope form: verb:resource (verb in read|write|invoke). sensitivity (low|medium|high) drives review attention; deviceCapabilityRequired is checked against the device by the production manifest strip.",
-  "catalogueVersion": "0.2.0-starter",
+  "catalogueVersion": "0.3.0-starter",
   "categories": [
     "team", "directory", "attendance", "timesheets", "scheduling", "availability", "leave", "clients",
-    "documents", "forms", "invoicing", "training", "comms", "files",
+    "care_plans", "documents", "forms", "invoicing", "training", "comms", "files",
     "partner", "device", "actions", "platform"
   ],
   "permissions": [
@@ -38,6 +38,8 @@ export default {
 
     { "scope": "read:clients", "category": "clients", "title": "Read clients", "description": "View client records.", "sensitivity": "high" },
     { "scope": "write:clients", "category": "clients", "title": "Write clients", "description": "Create or edit client records.", "sensitivity": "high" },
+
+    { "scope": "read:care_plans", "category": "care_plans", "title": "Read care plans", "description": "View NDIS care plans, service agreements, participant NDIS numbers, price items and budget health. Added 0.3.0-starter for the Invoicing MP's NDIS line-item generation, which reads care-plans.participant_ndis_number / ndis_price / budget_health across the bus.", "sensitivity": "high" },
 
     { "scope": "read:documents", "category": "documents", "title": "Read documents", "description": "View documents in scope.", "sensitivity": "medium" },
     { "scope": "write:documents", "category": "documents", "title": "Write documents", "description": "Upload or edit documents.", "sensitivity": "high" },

--- a/packages/manifest/src/catalogue/permission-catalogue.json
+++ b/packages/manifest/src/catalogue/permission-catalogue.json
@@ -1,9 +1,9 @@
 {
   "_comment": "VENDORED FROM plans/refactor-plan/05-deliverables/02-manifest-tooling/permission-catalogue.sample.json — this copy is the runtime source of truth shipped inside @tommy/manifest (a pinned @tommy/manifest version = a pinned catalogue version). The catalogue is FIXED and versioned (Phase 3 Q2) — MPs may only request scopes that appear here; @tommy/manifest validate layer 3 rejects any non-member with the named rule 'permission-not-in-catalogue'. This is the M1 STARTER set (covers every scope the reference manifest uses); the EXHAUSTIVE production catalogue is a deliberate, reviewed Tommy authoring task before M4 (README:68, security-model.md §2) — NOT an M1 gate. Growing it: add entries here, bump catalogueVersion, review. Scope form: verb:resource (verb in read|write|invoke). sensitivity (low|medium|high) drives review attention; deviceCapabilityRequired is checked against the device by the production manifest strip.",
-  "catalogueVersion": "0.2.0-starter",
+  "catalogueVersion": "0.3.0-starter",
   "categories": [
     "team", "directory", "attendance", "timesheets", "scheduling", "availability", "leave", "clients",
-    "documents", "forms", "invoicing", "training", "comms", "files",
+    "care_plans", "documents", "forms", "invoicing", "training", "comms", "files",
     "partner", "device", "actions", "platform"
   ],
   "permissions": [
@@ -34,6 +34,8 @@
 
     { "scope": "read:clients", "category": "clients", "title": "Read clients", "description": "View client records.", "sensitivity": "high" },
     { "scope": "write:clients", "category": "clients", "title": "Write clients", "description": "Create or edit client records.", "sensitivity": "high" },
+
+    { "scope": "read:care_plans", "category": "care_plans", "title": "Read care plans", "description": "View NDIS care plans, service agreements, participant NDIS numbers, price items and budget health. Added 0.3.0-starter for the Invoicing MP's NDIS line-item generation, which reads care-plans.participant_ndis_number / ndis_price / budget_health across the bus.", "sensitivity": "high" },
 
     { "scope": "read:documents", "category": "documents", "title": "Read documents", "description": "View documents in scope.", "sensitivity": "medium" },
     { "scope": "write:documents", "category": "documents", "title": "Write documents", "description": "Upload or edit documents.", "sensitivity": "high" },


### PR DESCRIPTION
## MP Actions convergence — Phase 1

**Base: `feature/mp-platform-build` (merges into Gav's working branch, not master).**
Sibling PRs (land together): tommy-sdk / tommy-sdk-private / tommy-app — cross-linked below.

### What this is

Converges all cross-MP interaction onto the Actions bus and makes the broker enforce, per the verified
audit in `mp-parity-inventory/gaps/ACTIONS_GAP_REGISTER.md` (Mason's machine — full plan/ledger/council
log in `mp-parity-inventory/execution/`). Zero intended user-visible change.

**Broker (tommy-sdk):** F6 same-MP re-entrancy deadlock fixed (the documented reason two writes went
off-bus); `authorizedCallers: []` = deny cross-MP; condition/trigger read-scope enforcement with
council-decided domain derivation (`read:shifts` grants scheduling's conditions; `SENSITIVE_CONDITIONS`
carve-out for kiosk_pin/vendor_settings); emit owner-assert; subscribe gating; tenant-scoped idempotency.
actions-runtime tests 15 → 57. All three enforcement flags **ON** at the app broker (sdk defaults off =
kill-switch).

**Per-MP (tommy-sdk-private):** every host-adapter read of another MP's domain swapped to a bus condition
query; off-bus writes routed through declared activities (availability locks B1, clients note-documents B5,
team invitations B10 + new resend/archive/save_team_setting activities, care-plans record_ndis_view B11,
time-clock→training record_video_view B4); `document_types` ownership moved forms→documents (E1, alias kept);
scheduling's dead 1,204-line off-bus write chain deleted (the publish-popup path was commented out —
its rebuild is Phase 2, on the bus); new conditions `time-clock.attendances_in_range`, scheduling SHS
surface + `calendar_display_settings`; `budget_health_changed` now emitted (transition-guarded);
duplicate imperative clock-out upsert removed (Action is sole producer, 17-case real-broker proof).

**Host (tommy-app):** six new activity adapters; `host.setAvailabilityLock` deleted; `platform:emit`
socket intake bound (name verified against tommy-api's platform_emitter.rb); scheduling rows added to
`vuexWriteMirror` (13 live shell readers of `workforce.shifts` confirmed — MP writes no longer go stale
in shell surfaces); batch-generator instant filter restored on the existing `windowCache` combinator.

### Gates

| Gate | Result |
|---|---|
| tommy-app unit | **1910/1911** (baseline 1816/1818 with 3 pre-existing reds → 2 fixed, +94 tests, 0 new reds; remaining red = the pre-existing `mp-m3-loop` split-shift premise vs guard B-3 — product question below) |
| sdk package suites | all green |
| coupling:check / depcruise / shared-deps / endpoint-literal grep | green, no rule increased |
| manifests | 17/17 validate |
| e2e | **no regression attributable** — identical suite re-run on the base commits: base 49F/241P vs branch 50F/239P; delta = 1 flake (passes 4/4 on re-run) + 1 prod-data contamination row. **BUT see the warning below.** |

### ⚠ Review-blocking finds for Gav (pre-existing, surfaced by this work)

1. **`yarn test:e2e` defaults to the PRODUCTION API** (`config.js` API_URL fallback) — local/CI runs
   mutate prod data. The 24 `mp-*` specs also never execute (their seeder shells `../api` which doesn't
   exist in a plain checkout), so MP e2e assertions have effectively never run. Recommend: default the
   suite to the local stack/mock and fix the seeder path. Until then, this branch's enforcement flips
   and mirror change carry **unit proof only** at the e2e level.
2. `core/src/mp/client.js` — every `mp/*` endpoint missing `apiVersion: 'api/v1'` (FE hits `/v1/mp/*` → 404).
3. 7 MP `bundle` scripts use plain esbuild (no Vue loader) — build via `app/scripts/build-mp.mjs` only.
4. `index_mp` 500s on object-form `activity` (api-side, `installs_controller.rb:79`) — fix exists locally on Mason's machine, api untouched by this PR.
5. Product question: should guard B-3 (`already_clocked_out`) forbid split shifts? `mp-m3-loop`'s premise says no, the guard says yes — one of them is wrong.

### Parked (documented in `execution/PARKED.md`, owners assigned)

B2 leave shift-link write (needs a v1.x contract addendum — Kam) · Action-dispatch identity binding
(council: declaring-MP; fix before any cross-MP Action condition gate is authored) · A3/A4 host-read
retirements · `_shift`/`_template` result side-channel · `shifts_in_range` missing `assigneeId` ·
`list_timesheets` shiftId filter.

### Contract

**v1.1 untouched** — no endpoint, wire-shape, or fixture changes. The one vocabulary addition is the
`care_plans` read domain in the client-side permission catalogue (0.3.0), granted to invoicing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Sibling PRs (land together)
- tommy-app: tommyassociates/tommy-app#332
- tommy-sdk-private: tommyassociates/tommy-sdk-private#174
- tommy-sdk: tommyassociates/tommy-sdk#43
