### PR TITLE
[STACKED → #43] MP parity completion (Phase 2) — legacyPackages identity declaration

### DIFF
--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -18,6 +18,7 @@
       "types": "./src/node.d.ts",
       "import": "./src/node.js"
     },
+    "./legacy-packages": "./src/legacy-packages.js",
     "./schema": "./src/schema/manifest-schema.json",
     "./catalogue": "./src/catalogue/permission-catalogue.json"
   },

--- a/packages/manifest/src/generated/manifest.ts
+++ b/packages/manifest/src/generated/manifest.ts
@@ -181,6 +181,10 @@ homepage?: string
  */
 locales?: [string, ...(string)[]]
 /**
+ * IDENTITY ADOPTION (council C3). Legacy addon package keys whose EXISTING install identity this MP adopts — the `addon_installs.package` values (snake_case, e.g. 'time_clock') that must activate this MP with zero tenant action. Read-time mapping ONLY: install rows are never written, migrated, or deleted because of this field. Entries must be globally unique across ALL loaded manifests (injectivity, asserted at load); an entry equal to this MP's own id simply declares that the identically-named legacy addon is this MP's. Absent means the MP has no legacy identity to adopt.
+ */
+legacyPackages?: string[]
+/**
  * Capability-based permission model. The MP receives a token bound to exactly these scopes; the host enforces them at the sandbox boundary.
  */
 permissions?: {

--- a/packages/manifest/src/index.d.ts
+++ b/packages/manifest/src/index.d.ts
@@ -69,3 +69,26 @@ export function loadSchema(): Record<string, unknown>;
 export function loadCatalogue(path?: string): Catalogue;
 export function searchCatalogue(catalogue: Catalogue, query?: CatalogueQuery): CatalogueEntry[];
 export function suggestScope(catalogue: Catalogue, unknown: string): string | null;
+
+// --- Identity adoption (council C3) ----------------------------------------
+
+export interface ManifestIdentitySummary {
+  id?: string;
+  legacyPackages?: string[];
+}
+
+export interface LegacyPackageIndex {
+  /** package key (legacy OR canonical) -> canonical mpId. */
+  byPackage: Map<string, string>;
+  /** canonical mpId -> the legacy package keys it adopts. */
+  byMpId: Map<string, string[]>;
+}
+
+export class LegacyPackageCollisionError extends Error {
+  packageKey?: string;
+  mpIds?: string[];
+}
+
+export function legacyPackagesOf(manifest: ManifestIdentitySummary): string[];
+export function buildLegacyPackageIndex(manifests: ManifestIdentitySummary[]): LegacyPackageIndex;
+export function resolveMpIdWith(index: LegacyPackageIndex, packageKey: string): string;

--- a/packages/manifest/src/index.js
+++ b/packages/manifest/src/index.js
@@ -10,3 +10,11 @@ export { validateManifest } from './validate.js';
 export { parseManifest } from './parse.js';
 export { loadSchema } from './schema.js';
 export { loadCatalogue, searchCatalogue, suggestScope } from './catalogue.js';
+// Identity adoption (council C3) — the ONE derivation of manifest-declared
+// `legacyPackages` into a package -> mpId index (injectivity asserted here).
+export {
+  legacyPackagesOf,
+  buildLegacyPackageIndex,
+  resolveMpIdWith,
+  LegacyPackageCollisionError,
+} from './legacy-packages.js';

--- a/packages/manifest/src/legacy-packages.js
+++ b/packages/manifest/src/legacy-packages.js
@@ -1,0 +1,105 @@
+/**
+ * legacy-packages.js — the IDENTITY-ADOPTION derivation (council C3).
+ *
+ * An MP that replaces a legacy addon ADOPTS the legacy install identity: the
+ * tenant's existing `addon_installs` row (package `time_clock`) must activate
+ * the MP (`time-clock`) with zero tenant action. The mapping is declared, per
+ * MP, by the manifest's optional `legacyPackages: []`, and is resolved at READ
+ * TIME only — nothing here ever writes, migrates, or deletes an install row.
+ *
+ * This module is the ONE derivation from those declarations. Consumers (the
+ * app's `mp-identity.js` authority, the validator, tooling) build an index here
+ * rather than re-deriving package strings themselves, so the injectivity rule
+ * is asserted in exactly one place.
+ *
+ * Browser-safe (no node built-ins) — the in-process loader imports it.
+ */
+
+/** Thrown when two manifests claim the same legacy package (injectivity). */
+export class LegacyPackageCollisionError extends Error {
+  constructor(message, { packageKey, mpIds } = {}) {
+    super(message);
+    this.name = 'LegacyPackageCollisionError';
+    this.packageKey = packageKey;
+    this.mpIds = mpIds;
+  }
+}
+
+/**
+ * The legacy package keys one manifest declares. Accepts a parsed manifest
+ * object or any `{ id, legacyPackages }` summary.
+ * @param {{id?: string, legacyPackages?: string[]}} manifest
+ * @returns {string[]}
+ */
+export function legacyPackagesOf(manifest) {
+  const declared = manifest && manifest.legacyPackages;
+  if (!Array.isArray(declared)) return [];
+  return declared.filter((p) => typeof p === 'string' && p.length > 0);
+}
+
+/**
+ * Build the package -> mpId index across every loaded manifest.
+ *
+ * INJECTIVITY (C3 rider, asserted here — the single assertion point):
+ *  - no package key may be claimed by two different MPs;
+ *  - a package key that equals some MP's canonical id may only be claimed by
+ *    THAT MP (otherwise `scheduling` would resolve away from the Scheduling MP).
+ *
+ * The canonical id is always its own key (`time-clock` -> `time-clock`), so the
+ * index answers both the legacy row and the canonical row with one lookup.
+ *
+ * @param {Array<{id?: string, legacyPackages?: string[]}>} manifests
+ * @returns {{ byPackage: Map<string,string>, byMpId: Map<string,string[]> }}
+ * @throws {LegacyPackageCollisionError}
+ */
+export function buildLegacyPackageIndex(manifests = []) {
+  const entries = (manifests || []).filter((m) => m && typeof m.id === 'string' && m.id);
+  const canonicalIds = new Set(entries.map((m) => m.id));
+
+  const byPackage = new Map();
+  const byMpId = new Map();
+
+  // Canonical ids first — an MP is always reachable by its own id.
+  for (const mp of entries) {
+    byPackage.set(mp.id, mp.id);
+    byMpId.set(mp.id, []);
+  }
+
+  for (const mp of entries) {
+    for (const pkg of legacyPackagesOf(mp)) {
+      // A key that is another MP's canonical id may never be re-pointed.
+      if (canonicalIds.has(pkg) && pkg !== mp.id) {
+        throw new LegacyPackageCollisionError(
+          `legacyPackages: '${pkg}' is the canonical id of another Mini Program — '${mp.id}' may not adopt it.`,
+          { packageKey: pkg, mpIds: [pkg, mp.id] },
+        );
+      }
+      const owner = byPackage.get(pkg);
+      if (owner !== undefined && owner !== mp.id) {
+        throw new LegacyPackageCollisionError(
+          `legacyPackages: '${pkg}' is declared by BOTH '${owner}' and '${mp.id}' — legacy package keys must be globally unique (injectivity).`,
+          { packageKey: pkg, mpIds: [owner, mp.id] },
+        );
+      }
+      byPackage.set(pkg, mp.id);
+      const list = byMpId.get(mp.id);
+      if (!list.includes(pkg)) list.push(pkg);
+    }
+  }
+
+  return { byPackage, byMpId };
+}
+
+/**
+ * Resolve one install/package key to its canonical mpId against an index built
+ * by `buildLegacyPackageIndex`. Unknown keys pass THROUGH unchanged (an MP the
+ * index does not know about must not be silently renamed).
+ * @param {{byPackage: Map<string,string>}} index
+ * @param {string} packageKey
+ * @returns {string}
+ */
+export function resolveMpIdWith(index, packageKey) {
+  if (!packageKey) return packageKey;
+  const hit = index && index.byPackage ? index.byPackage.get(packageKey) : undefined;
+  return hit === undefined ? packageKey : hit;
+}

--- a/packages/manifest/src/schema/manifest-schema.embedded.js
+++ b/packages/manifest/src/schema/manifest-schema.embedded.js
@@ -54,6 +54,17 @@ export default {
       "items": { "type": "string", "pattern": "^[a-z]{2}(-[A-Z]{2})?$" }
     },
 
+    "legacyPackages": {
+      "description": "IDENTITY ADOPTION (council C3). Legacy addon package keys whose EXISTING install identity this MP adopts — the `addon_installs.package` values (snake_case, e.g. 'time_clock') that must activate this MP with zero tenant action. Read-time mapping ONLY: install rows are never written, migrated, or deleted because of this field. Entries must be globally unique across ALL loaded manifests (injectivity, asserted at load); an entry equal to this MP's own id simply declares that the identically-named legacy addon is this MP's. Absent means the MP has no legacy identity to adopt.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "description": "A legacy addon package key. Underscores allowed here (the MP `id` pattern stays underscore-free) — this field is where legacy keys live. Hyphens are accepted too so an MP may name the identically-titled legacy addon when its own id is hyphenated.",
+        "pattern": "^[a-z][a-z0-9_-]*[a-z0-9]$"
+      }
+    },
+
     "permissions": {
       "description": "Capability-based permission model. The MP receives a token bound to exactly these scopes; the host enforces them at the sandbox boundary.",
       "type": "object",

--- a/packages/manifest/src/schema/manifest-schema.json
+++ b/packages/manifest/src/schema/manifest-schema.json
@@ -50,6 +50,17 @@
       "items": { "type": "string", "pattern": "^[a-z]{2}(-[A-Z]{2})?$" }
     },
 
+    "legacyPackages": {
+      "description": "IDENTITY ADOPTION (council C3). Legacy addon package keys whose EXISTING install identity this MP adopts — the `addon_installs.package` values (snake_case, e.g. 'time_clock') that must activate this MP with zero tenant action. Read-time mapping ONLY: install rows are never written, migrated, or deleted because of this field. Entries must be globally unique across ALL loaded manifests (injectivity, asserted at load); an entry equal to this MP's own id simply declares that the identically-named legacy addon is this MP's. Absent means the MP has no legacy identity to adopt.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "description": "A legacy addon package key. Underscores allowed here (the MP `id` pattern stays underscore-free) — this field is where legacy keys live. Hyphens are accepted too so an MP may name the identically-titled legacy addon when its own id is hyphenated.",
+        "pattern": "^[a-z][a-z0-9_-]*[a-z0-9]$"
+      }
+    },
+
     "permissions": {
       "description": "Capability-based permission model. The MP receives a token bound to exactly these scopes; the host enforces them at the sandbox boundary.",
       "type": "object",

--- a/packages/manifest/test/legacy-packages.test.js
+++ b/packages/manifest/test/legacy-packages.test.js
@@ -1,0 +1,137 @@
+// IDENTITY ADOPTION (council C3) — the `legacyPackages` manifest field and the
+// ONE derivation that turns those declarations into a package -> mpId index.
+//
+// The field lets an MP adopt the install identity of the legacy addon it
+// replaces (`addon_installs.package` = `time_clock` -> the `time-clock` MP).
+// The schema constrains the shape; `buildLegacyPackageIndex` asserts the
+// cross-manifest injectivity rule the resolver depends on.
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateManifest,
+  legacyPackagesOf,
+  buildLegacyPackageIndex,
+  resolveMpIdWith,
+  LegacyPackageCollisionError,
+} from '../src/index.js';
+
+const IDENTITY = [
+  'manifestVersion: "1"',
+  'id: time-clock',
+  'version: 1.0.0',
+  'name: Time Clock',
+  'category: time_attendance',
+  'publisher: { id: x, name: X, type: first_party }',
+].join('\n');
+
+const withBody = (body) => `${IDENTITY}\n${body}\n`;
+
+describe('schema: legacyPackages', () => {
+  it('is OPTIONAL — a manifest without it stays valid', () => {
+    expect(validateManifest(`${IDENTITY}\n`).ok).toBe(true);
+  });
+
+  it('accepts underscored legacy keys (the MP id pattern stays underscore-free)', () => {
+    const res = validateManifest(withBody('legacyPackages:\n  - time_clock'));
+    expect(res.errors).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts a key equal to the MP id (the identically-named legacy addon is mine)', () => {
+    const res = validateManifest(withBody('legacyPackages:\n  - time-clock'));
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects a duplicate entry within one manifest', () => {
+    const res = validateManifest(withBody('legacyPackages:\n  - time_clock\n  - time_clock'));
+    expect(res.ok).toBe(false);
+    expect(res.errors[0].rule).toBe('duplicate-item');
+  });
+
+  it('rejects a malformed key (uppercase / leading underscore / trailing underscore)', () => {
+    for (const bad of ['Time_Clock', '_time_clock', 'time_clock_']) {
+      const res = validateManifest(withBody(`legacyPackages:\n  - ${bad}`));
+      expect(res.ok).toBe(false);
+      expect(res.errors[0].rule).toBe('pattern-mismatch');
+    }
+  });
+
+  it('rejects a non-array value', () => {
+    const res = validateManifest(withBody('legacyPackages: time_clock'));
+    expect(res.ok).toBe(false);
+    expect(res.errors[0].rule).toBe('invalid-type');
+  });
+});
+
+describe('legacyPackagesOf', () => {
+  it('returns the declared keys, or [] when absent/malformed', () => {
+    expect(legacyPackagesOf({ id: 'a', legacyPackages: ['x_y'] })).toEqual(['x_y']);
+    expect(legacyPackagesOf({ id: 'a' })).toEqual([]);
+    expect(legacyPackagesOf(null)).toEqual([]);
+    expect(legacyPackagesOf({ id: 'a', legacyPackages: 'x' })).toEqual([]);
+  });
+});
+
+describe('buildLegacyPackageIndex — injectivity', () => {
+  const estate = [
+    { id: 'time-clock', legacyPackages: ['time_clock'] },
+    { id: 'care-plans', legacyPackages: ['care_plans'] },
+    { id: 'scheduling', legacyPackages: ['scheduling'] },
+    { id: 'leave' },
+  ];
+
+  it('indexes every canonical id and every adopted legacy key', () => {
+    const index = buildLegacyPackageIndex(estate);
+    expect(index.byPackage.get('time_clock')).toBe('time-clock');
+    expect(index.byPackage.get('time-clock')).toBe('time-clock');
+    expect(index.byPackage.get('care_plans')).toBe('care-plans');
+    expect(index.byPackage.get('scheduling')).toBe('scheduling');
+    expect(index.byPackage.get('leave')).toBe('leave');
+    expect(index.byMpId.get('time-clock')).toEqual(['time_clock']);
+    expect(index.byMpId.get('leave')).toEqual([]);
+  });
+
+  it('THROWS when two MPs claim the same legacy package', () => {
+    const call = () => buildLegacyPackageIndex([
+      { id: 'time-clock', legacyPackages: ['time_clock'] },
+      { id: 'timesheets', legacyPackages: ['time_clock'] },
+    ]);
+    expect(call).toThrow(LegacyPackageCollisionError);
+    expect(call).toThrow(/globally unique/);
+  });
+
+  it("THROWS when an MP claims ANOTHER MP's canonical id", () => {
+    const call = () => buildLegacyPackageIndex([
+      { id: 'timesheets', legacyPackages: ['scheduling'] },
+      { id: 'scheduling' },
+    ]);
+    expect(call).toThrow(LegacyPackageCollisionError);
+    expect(call).toThrow(/canonical id of another/);
+  });
+
+  it('tolerates the same MP declaring the same key twice (idempotent)', () => {
+    const index = buildLegacyPackageIndex([{ id: 'a', legacyPackages: ['a_b', 'a_b'] }]);
+    expect(index.byMpId.get('a')).toEqual(['a_b']);
+  });
+
+  it('ignores entries with no id', () => {
+    expect(() => buildLegacyPackageIndex([null, {}, { legacyPackages: ['x'] }])).not.toThrow();
+  });
+});
+
+describe('resolveMpIdWith', () => {
+  const index = buildLegacyPackageIndex([{ id: 'time-clock', legacyPackages: ['time_clock'] }]);
+
+  it('maps a legacy key onto the canonical id', () => {
+    expect(resolveMpIdWith(index, 'time_clock')).toBe('time-clock');
+  });
+
+  it('is the identity for a canonical id', () => {
+    expect(resolveMpIdWith(index, 'time-clock')).toBe('time-clock');
+  });
+
+  it('passes an unknown key THROUGH (never invents an mpId)', () => {
+    expect(resolveMpIdWith(index, 'wallet_accounts')).toBe('wallet_accounts');
+    expect(resolveMpIdWith(index, '')).toBe('');
+  });
+});


### PR DESCRIPTION
## MP parity completion — Phase 2

**⚠ STACKED: base = `feature/mp-actions-convergence` (merge tommy-app#332 / tommy-sdk-private#174 / tommy-sdk#43 first; this PR then merges into that branch, not `feature/mp-platform-build` directly).**
Siblings (land together): tommy-app / tommy-sdk-private / tommy-sdk, same branch name.

### What this is

Completes the 1:1 legacy→MP port for all 13 addon-descended MPs, arbitrated by a new **pixel parity
harness** — flag-off legacy vs flag-on MP screenshot pairs, mock-only network (a NO-PROD guard aborts any
non-localhost request), measured DOM diffing, committed legacy baselines. Plus the **identity-adoption
layer** (council C3): manifest-declared `legacyPackages`, one `resolveMpId`/`packageForInstallWrite`
authority, canonical-wins both-rows precedence, kill-switch copy, and a four-tenant adoption test matrix —
**zero install rows written, ever**.

### Final gates

| Gate | Result |
|---|---|
| Pixel parity | **40 surfaces passed / 16 parked-with-reason / 0 failed** — no masks, budgets at 0.005 |
| tommy-app unit | **2020/2021** (+204 tests over Phase 1; the 1 red is the pre-existing `mp-m3-loop` split-shift product question) |
| identity adoption | 27/27 (legacy-only / canonical-only / both-rows / never-installed tenants) |
| provider-swap / workforce-convergence | green (stub worlds intact; single-upsert clock-out proof holds) |

### Highlights

- **Leave**: MP-native form + details popups replace the legacy shared-addon delegation (16 rows), soft-reject seam closed.
- **Training**: the whole manager Videos vertical built (library, form/details/watch popups) on the declared bus activities.
- **Scheduling**: all 68 inventory rows resolved — grid/header/shift-form/publish/cold-start/day-timeline/range-picker/swapped-axis at 0-diff or sub-budget; publish confirmed already bus-wired.
- **Forms/Documents/Onboarding**: plain-HTML panels rebuilt on real F7 + tommy-core chrome.
- 6 **fixture bugs** and 4 **legacy defects** found en route (see below) — MPs were NOT regressed to match legacy bugs.

### Parked — needs a human

1. **Legacy-code REMOVAL holds on tommy-api**: token mint rejects legacy-only tenants (`TokensController#install_for` joins `addons.package`, no aliasing; the claim also stamps the legacy id). Kam item; verified empirically against `backend-merged`.
2. **Design rulings (Mason+Gav)**: invoicing batch-generator + payment-report layouts and care-plans list style are deliberate MP redesigns vs legacy — ratify or request legacy-exact ports (pairs parked).
3. **Legacy defects found (fix in legacy, pairs parked on them)**: `documents.vue:204` user-id filter (empties the manager Documents page); time-clock `showOverviewPage()` flag-off nav recursion; training details empty value card; `mp-m3-loop` split-shift premise vs guard B-3.
4. `training.assign_video` activity undeclared (row 15); onboarding wizard pair needs per-side viewport + non-manager fixture viewer.

Full ledger/council log/parked register: `mp-parity-inventory/execution/` on Mason's machine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
